### PR TITLE
enable window communication

### DIFF
--- a/app/modules/session/components/connect-btn/connect_btn.component.ts
+++ b/app/modules/session/components/connect-btn/connect_btn.component.ts
@@ -1,4 +1,6 @@
 import {Component} from '@angular/core';
+import {Session} from '../../models/session.model';
+import setInterval = core.setInterval;
 
 @Component({
   moduleId: module.id,
@@ -7,23 +9,51 @@ import {Component} from '@angular/core';
   styleUrls: ['connect_btn.style.css']
 })
 export class ConnectBtnComponent {
-  connect() {
-    window.open('https://soundcloud.com/connect?' +
-      'client_id=abb6c1cad3f409112a5995bf922e1d1e&' +
-      'redirect_uri=http://sc.menu-flow.com/connect&' +
-      'response_type=code&' +
-      'state=' + window.location.origin + window.location.pathname
-    );
-  }
+  private session: Session = Session.getInstance();
+  private checkInterval: number;
 
   private receiveConnectMessage(event: any): void {
     let origin = event.origin || event.originalEvent.origin;
-    if (origin !== window.location.origin) {
-      console.log('JOO');
+    if (origin !== 'http://sc.menu-flow.com') {
+      return;
     }
+    this.connectionSuccessFul(event.data);
+  }
+
+  getConnectionUrl(): string {
+    return '//soundcloud.com/connect?' +
+      'client_id=abb6c1cad3f409112a5995bf922e1d1e&' +
+      'redirect_uri=http://sc.menu-flow.com/connect&' +
+      'response_type=code';
+  }
+
+  connect() {
+    let popup = window.open(this.getConnectionUrl());
+    this.checkInterval = setInterval(() => {
+      popup.postMessage(null, 'http://sc.menu-flow.com');
+    }, 100);
+  }
+
+  connectionSuccessFul(params: any) {
+    this.session.set({
+      access_token: params.access_token,
+      expires_on: params.expires_on,
+      refresh_token: params.refresh_token
+    });
   }
 
   constructor() {
-    window.addEventListener('message', this.receiveConnectMessage, false);
+    window.addEventListener('message', this.receiveConnectMessage.bind(this), false);
+    window.addEventListener('connectionSuccessFul', (ev: CustomEvent) => {
+      let creds = ev.detail;
+      if (creds) {
+        try {
+          creds = JSON.parse(creds);
+        } catch (err) {
+
+        }
+        this.connectionSuccessFul(creds);
+      }
+    });
   }
 }

--- a/server/connect/index.php
+++ b/server/connect/index.php
@@ -31,11 +31,11 @@ function getExpiresOn($expiresIn){
 
 function successAuth($jsonData){
   if($_GET['state']){
-   $url = $_GET['state'];
+   $url = $_GET['state'].'#/connect';
   } else {
-   $url = 'http://localhost:3000/#/connect';
+   $url = 'http://sc.menu-flow.com/connect/success.php';
   }
-  $url = $url . '#/connect' .
+  $url = $url .
            '?access_token='  . $jsonData->access_token  .
            '&expires_on='    . getExpiresOn($jsonData->expires_in)    .
            '&refresh_token=' . $jsonData->refresh_token;

--- a/server/connect/success.php
+++ b/server/connect/success.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Cloud Player-Sucessfully connected</title>
+</head>
+<body>
+The connection to Soundcloud was successful.
+<script>
+  var response = {
+    access_token: "<?php echo $_GET['access_token'] ?>",
+    expires_on: <?php echo $_GET['expires_on'] ?>,
+    refresh_token: "<?php echo $_GET['refresh_token'] ?>"
+  };
+
+  function receiveMessage(event)
+  {
+    event.source.postMessage(response, event.origin);
+    window.close();
+  }
+  window.addEventListener("message", receiveMessage, false);
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
the app ist listening on a `connectionSuccessFul` event on the window. When the event arrives it will set the session with the creds that are attached to the event. the event will be fired e.g. by the native-electron app.
It is also listening on messages of the opened modal when you click on connect. The popup can post a message to its parent window. When the message arrives it will set the session