### PR TITLE
Fix/sort descending

### DIFF
--- a/app/modules/backbone/collections/base.collection.ts
+++ b/app/modules/backbone/collections/base.collection.ts
@@ -13,6 +13,24 @@ export class BaseCollection<TModel extends BaseModel> extends Collection<TModel>
 
   endpoint: string = null;
 
+  sortOrder: string = null;
+
+  private setSearchParams(searchParams: URLSearchParams, obj: {} = {}, discardKeys: Array<string> = []): URLSearchParams {
+    Object.keys(obj).forEach((key) => {
+      if (discardKeys.indexOf(key) === -1) {
+        searchParams.set(key, this.queryParams[key]);
+      }
+    });
+    return searchParams;
+  }
+
+  constructor() {
+    super();
+    this.on('sync', () => {
+      this.sortOrder = null;
+    });
+  }
+
   hostName(): string {
     return '';
   };
@@ -24,15 +42,6 @@ export class BaseCollection<TModel extends BaseModel> extends Collection<TModel>
   url = () => {
     return getUrl(this);
   };
-
-  private setSearchParams(searchParams: URLSearchParams, obj: {} = {}, discardKeys: Array<string> = []): URLSearchParams {
-    Object.keys(obj).forEach((key) => {
-      if (discardKeys.indexOf(key) === -1) {
-        searchParams.set(key, this.queryParams[key]);
-      }
-    });
-    return searchParams;
-  }
 
   sync(method: string, model: any, options: any = {}) {
     let searchParams: URLSearchParams;
@@ -65,7 +74,21 @@ export class BaseCollection<TModel extends BaseModel> extends Collection<TModel>
     options.search = queryParams;
     return super.fetch(options);
   }
-  ;
+
+  sortAscending() {
+    this.sort();
+    this.sortOrder = 'ASC';
+  }
+
+  sortDescending() {
+    if (this.sortOrder !== 'ASC') {
+      this.sortAscending();
+    }
+    this.models = this.models.reverse();
+    this.trigger('sort', this);
+    this.sortOrder = 'DESC';
+  }
+
 }
 
 

--- a/app/modules/backbone/components/collection-sort-component/collection-sort.component.ts
+++ b/app/modules/backbone/components/collection-sort-component/collection-sort.component.ts
@@ -16,41 +16,41 @@ export class CollectionSortComponent {
 
   @Input() label: string;
 
-  isDescendingSorted: boolean = false;
+  sortDesc: boolean = true;
 
   isSorted(): boolean {
-    return this.collection && this.collection.comparator === this.comparator;
-  }
-
-  sortDesending(): void {
-    this.collection.set(this.collection.models.reverse());
+    return this.collection &&
+      (
+        (this.collection.comparator === this.comparator) ||
+        (!this.comparator && !this.collection.comparator)
+      );
   }
 
   sort(): void {
     if (this.comparator) {
-      if (!this.isSorted()) {
-        this.isDescendingSorted = false;
+      if (this.collection.length < 2) {
+        return;
       }
-
-      this.collection.comparator = this.comparator;
-      this.collection.sort();
-
-      if (!this.isDescendingSorted) {
-        this.sortDesending();
+      if (this.collection.comparator !== this.comparator) {
+        this.collection.sortOrder = null;
+        this.collection.comparator = this.comparator;
       }
-
-      this.isDescendingSorted = !this.isDescendingSorted;
-
+      if (!this.collection.sortOrder || this.collection.sortOrder === 'ASC') {
+        this.collection.sortDescending();
+      } else {
+        this.collection.sortAscending();
+      }
+    } else if (this.collection.comparator) {
+      this.collection.comparator = null;
+      this.collection.fetch({sort: false});
     }
   }
 
   ngOnInit() {
-    this.collection.on('reset', () => {
-      if (this.isSorted() && this.isDescendingSorted) {
-        this.sortDesending();
+    this.collection.on('sync', () => {
+      if (this.isSorted() && this.comparator) {
+        this.collection.sortDescending();
       }
-      console.log('RESET');
     });
   }
-
 }

--- a/app/modules/backbone/components/collection-sort-component/collection-sort.template.html
+++ b/app/modules/backbone/components/collection-sort-component/collection-sort.template.html
@@ -1,8 +1,8 @@
 <span (click)="sort()" [style.font-weight]="isSorted()?'bold':'normal'">
   <i *ngIf="isSorted()"
      class="fa fa-angle-up"
-     [class.fa-angle-up]="!isDescendingSorted"
-     [class.fa-angle-down]="isDescendingSorted"
+     [class.fa-angle-up]="collection.sortOrder === 'ASC' && comparator"
+     [class.fa-angle-down]="collection.sortOrder === 'DESC' && comparator"
      aria-hidden="true"></i>
   {{label}}
 </span>

--- a/app/modules/dashboard/components/index/index.template.html
+++ b/app/modules/dashboard/components/index/index.template.html
@@ -9,19 +9,7 @@
 
   <hr>
 
-  <div class="sort-tracks">
-    Sort items by:
-    <collection-sort [collection]="tracks" [label]="'None'"></collection-sort>
-    |
-    <collection-sort [collection]="tracks" [comparator]="'duration'" [label]="'Duration'"></collection-sort>
-    |
-    <collection-sort [collection]="tracks" [comparator]="'likes_count'" [label]="'Likes'"></collection-sort>
-    |
-    <collection-sort [collection]="tracks" [comparator]="'playback_count'" [label]="'Plays'"></collection-sort>
-    |
-    <collection-sort [collection]="tracks" [comparator]="'created_at'" [label]="'Created At'"></collection-sort>
-  </div>
-
+  <sort-tracks [tracks]="tracks"></sort-tracks>
 
   <track-list [tracks]="tracks"></track-list>
 </div>

--- a/app/modules/dashboard/components/index/index.template.html
+++ b/app/modules/dashboard/components/index/index.template.html
@@ -11,6 +11,8 @@
 
   <div class="sort-tracks">
     Sort items by:
+    <collection-sort [collection]="tracks" [label]="'None'"></collection-sort>
+    |
     <collection-sort [collection]="tracks" [comparator]="'duration'" [label]="'Duration'"></collection-sort>
     |
     <collection-sort [collection]="tracks" [comparator]="'likes_count'" [label]="'Likes'"></collection-sort>

--- a/app/modules/playlists/components/playlist-view/playlist-view.template.html
+++ b/app/modules/playlists/components/playlist-view/playlist-view.template.html
@@ -3,5 +3,9 @@
     {{playlist.get('title')}}
   </h3>
 
+  <hr>
+
+  <sort-tracks [tracks]="playlist.get('tracks')"></sort-tracks>
+
   <track-list [tracks]="playlist.get('tracks')"></track-list>
 </div>

--- a/app/modules/session/components/liked-tracks-view/liked-tracks-view.template.html
+++ b/app/modules/session/components/liked-tracks-view/liked-tracks-view.template.html
@@ -3,5 +3,9 @@
     Liked Tracks
   </h3>
 
+  <hr>
+
+  <sort-tracks [tracks]="user.get('likes')"></sort-tracks>
+
   <track-list [tracks]="user.get('likes')"></track-list>
 </div>

--- a/app/modules/shared/components/sort-tracks/sort-tracks.component.ts
+++ b/app/modules/shared/components/sort-tracks/sort-tracks.component.ts
@@ -1,0 +1,15 @@
+import {Component, Input} from '@angular/core';
+import {Tracks} from '../../../tracks/collections/tracks.collection';
+import {Track} from '../../../tracks/models/track.model';
+
+@Component({
+  moduleId: module.id,
+  selector: 'sort-tracks',
+  templateUrl: 'sort-tracks.template.html',
+  styleUrls: ['sort-tracks.style.css']
+})
+export class SortTracksComponent {
+
+  @Input() tracks: Tracks<Track>;
+
+}

--- a/app/modules/shared/components/sort-tracks/sort-tracks.template.html
+++ b/app/modules/shared/components/sort-tracks/sort-tracks.template.html
@@ -1,0 +1,12 @@
+<div class="sort-tracks">
+  Sort tracks by:
+  <collection-sort [collection]="tracks" [label]="'None'"></collection-sort>
+  |
+  <collection-sort [collection]="tracks" [comparator]="'duration'" [label]="'Duration'"></collection-sort>
+  |
+  <collection-sort [collection]="tracks" [comparator]="'likes_count'" [label]="'Likes'"></collection-sort>
+  |
+  <collection-sort [collection]="tracks" [comparator]="'playback_count'" [label]="'Plays'"></collection-sort>
+  |
+  <collection-sort [collection]="tracks" [comparator]="'created_at'" [label]="'Created At'"></collection-sort>
+</div>

--- a/app/modules/shared/shared.module.ts
+++ b/app/modules/shared/shared.module.ts
@@ -5,16 +5,20 @@ import {ToggleLikedTrackComponent} from './components/toggle-liked-track-compone
 import {PlayButtonComponent} from './components/play-button/play_button.component';
 import {BrowserModule} from '@angular/platform-browser';
 import {QueueButtonComponent} from './components/queue-button/queue_button.component';
+import {SortTracksComponent} from './components/sort-tracks/sort-tracks.component';
+import {BackboneModule} from '../backbone/backbone.module';
 
 @NgModule({
   imports: [
-    BrowserModule
+    BrowserModule,
+    BackboneModule
   ],
   declarations: [
     TrackListComponent,
     ToggleLikedTrackComponent,
     PlayButtonComponent,
     QueueButtonComponent,
+    SortTracksComponent,
     HumanReadableSecondsPipe
   ],
   exports: [
@@ -22,6 +26,7 @@ import {QueueButtonComponent} from './components/queue-button/queue_button.compo
     ToggleLikedTrackComponent,
     PlayButtonComponent,
     QueueButtonComponent,
+    SortTracksComponent,
     HumanReadableSecondsPipe
   ]
 })


### PR DESCRIPTION
-The descending sort did not work properly. There is no way to tell backbone to sort descending therefore it has to be implemented as a workaround by reversing the models.
- It is now possible to reset the sort order by passing no comparator. It will then refetch the collection
- Extracted the sort bar of the dashbaord view into a sort tracks component so to use it for the playlist and likes view as well