### PR TITLE
Feature/save all the things

### DIFF
--- a/app/modules/audioplayer/collections/play_queue.collection.ts
+++ b/app/modules/audioplayer/collections/play_queue.collection.ts
@@ -1,8 +1,8 @@
 import {PlayQueueItem} from '../models/play_queue_item.model';
-import {BaseCollection} from '../../backbone/collections/base.collection';
 import {isArray} from 'underscore';
+import {SoundcloudCollection} from '../../main/collections/soundcloud.collection';
 
-export class PlayQueue<TModel extends PlayQueueItem> extends BaseCollection<TModel> {
+export class PlayQueue<TModel extends PlayQueueItem> extends SoundcloudCollection<TModel> {
   private static instance: PlayQueue<PlayQueueItem>;
 
   private playIndex = 0;
@@ -18,6 +18,70 @@ export class PlayQueue<TModel extends PlayQueueItem> extends BaseCollection<TMod
     }
   }
 
+  private getMiniItem(playQueueItem: PlayQueueItem): {} {
+    let mini = playQueueItem.toJSON(true);
+    mini.track = {
+      id: mini.track.id
+    };
+    if (mini.status === 'PLAYING') {
+      mini.status = 'PAUSED';
+    }
+    return mini;
+  }
+
+  private pushMiniItems(items: Array<PlayQueueItem>, allItems: Array<any>, maxItems?: number): Array<any> {
+    items.forEach((item: PlayQueueItem) => {
+      if (maxItems && allItems.length > maxItems) {
+        return;
+      }
+      allItems.push(this.getMiniItem(item));
+    });
+    return allItems;
+  }
+
+  getScheduledItemsJSON(maxItems: number): Array<{}> {
+    let allItems: Array<{}> = [],
+      queuedItems = this.getQueuedItems(),
+      scheduledItems = this.getScheduledItems(),
+      currentItem = this.getCurrentItem();
+
+    if (currentItem) {
+      allItems.push(this.getMiniItem(currentItem));
+    }
+    this.pushMiniItems(queuedItems, allItems, maxItems);
+    this.pushMiniItems(scheduledItems, allItems, maxItems);
+    return allItems;
+  }
+
+  parse(attrs: any): any {
+    let data: any = [];
+    attrs.forEach((track: any) => {
+      data.push({
+        id: track.id,
+        track: track
+      });
+    });
+    return data;
+  }
+
+  fetchTrackInformationOfAllAddedTracks(): void {
+    if (this.length === 0) {
+      return;
+    }
+
+    let ids = this.map((item) => {
+      return item.get('track').id;
+    }).join(',');
+
+    this.fetch(<any>{
+      url: '//api.soundcloud.com/tracks',
+      search: {
+        ids: ids
+      },
+      merge: true,
+      add: false
+    });
+  }
 
   getQueuedItems(): TModel[] {
     return this.where({status: 'QUEUED'});

--- a/app/modules/audioplayer/components/audio-player-controls/audio-player-controls.template.html
+++ b/app/modules/audioplayer/components/audio-player-controls/audio-player-controls.template.html
@@ -1,8 +1,8 @@
-<button type="button" (click)="previousTrack()" [disabled]="!playQueue.hasPreviousItem()">
+<button type="button" (click)="previousTrack()" [disabled]="!playQueue.hasPreviousItem() && audio.currentTime < 1">
   <i class="fa fa-backward" aria-hidden="true"></i>
 </button>
 
-<button type="button" (click)="playTrack()" *ngIf="!playQueue.getPlayingItem()">
+<button type="button" (click)="playTrack()" *ngIf="!playQueue.getPlayingItem()" [disabled]="playQueue.getCurrentItem() && !playQueue.getCurrentItem().get('track').get('stream_url')">
   <i class="fa fa-play" aria-hidden="true"></i>
 </button>
 
@@ -15,6 +15,6 @@
 </button>
 
 <range-slider min="0" max="1" [value]="audio.volume" step="0.01" (valueChange)="setVolume($event)" (valueChanged)="saveVolume($event)"></range-slider>
-<range-slider min="0" [max]="audio.duration" [value]="timeTick" step="0.01" (valueChanged)="playTrackFromPosition($event)" [isLoading]="isBuffering"></range-slider>
+<range-slider min="0" [max]="duration" [value]="timeTick" step="0.01" (valueChanged)="playTrackFromPosition($event)" [isLoading]="isBuffering"></range-slider>
 <span>{{timeTick | hReadableSeconds}}</span>
 <span> {{duration | hReadableSeconds}} </span>

--- a/app/modules/audioplayer/models/play_queue_item.model.ts
+++ b/app/modules/audioplayer/models/play_queue_item.model.ts
@@ -1,7 +1,7 @@
 import {Track} from '../../tracks/models/track.model';
-import {BaseModel} from '../../backbone/models/base.model';
+import {SoundcloudModel} from '../../main/models/soundcloud.model';
 
-export class PlayQueueItem extends BaseModel {
+export class PlayQueueItem extends SoundcloudModel {
 
   defaults() {
     return {

--- a/app/modules/backbone/collections/base.collection.ts
+++ b/app/modules/backbone/collections/base.collection.ts
@@ -65,16 +65,6 @@ export class BaseCollection<TModel extends BaseModel> extends Collection<TModel>
     return super.sync(method, model, options);
   }
 
-
-  fetch(options: any = {}) {
-    let queryParams = new URLSearchParams();
-    Object.keys(this.queryParams).forEach((prop) => {
-      queryParams.set(prop, this.queryParams[prop]);
-    });
-    options.search = queryParams;
-    return super.fetch(options);
-  }
-
   sortAscending() {
     this.sort();
     this.sortOrder = 'ASC';

--- a/app/vendor.ts
+++ b/app/vendor.ts
@@ -4,3 +4,4 @@ import 'reflect';
 import 'backbone';
 import 'underscore';
 import 'jquery';
+import 'localforage';

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/underscore": "^1.7.33",
     "backbone": "1.3.3",
     "bootstrap-sass": "^3.3.7",
+    "localforage": "1.4.3",
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",
     "ng2-bs3-modal": "^0.10.4",
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@types/core-js": "^0.9.34",
     "@types/jasmine": "^2.5.35",
+    "@types/localforage": "0.0.33",
     "@types/node": "^6.0.45",
     "@types/selenium-webdriver": "^2.53.32",
     "canonical-path": "0.0.2",

--- a/systemjs.config.dev.js
+++ b/systemjs.config.dev.js
@@ -30,6 +30,7 @@
       'backbone': 'npm:backbone/backbone.js',
       'underscore': 'npm:underscore/underscore.js',
       'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
+      'localforage': 'npm:localforage/dist/localforage.js',
 
       //shims
       'core-js-shim':'npm:core-js/client/shim.min.js',

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -30,6 +30,7 @@
       'backbone': 'npm:backbone/backbone.js',
       'underscore': 'npm:underscore/underscore.js',
       'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
+      'localforage': 'npm:localforage/dist/localforage.js',
 
       //shims
       'core-js-shim':'npm:core-js/client/shim.min.js',


### PR DESCRIPTION
- Use localforage instead of localstorage. It has the same API but uses index db when available. Index db is async and therefore does not block the ui on read/write
- Save the play queue into a local storage and populate on the play queue on application startup
- Save current playing track with the current playtime into a local storage and reinitialise on app startup